### PR TITLE
Updating python version from 3.6 to 3.9

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -19,7 +19,7 @@ provider:
   name: aws
   profile: ${self:custom.profile}
   stage: ${self:custom.stage}
-  runtime: python3.6
+  runtime: python3.9
   environment:
     LOG_LEVEL: ${self:custom.log_level}
   stackTags:


### PR DESCRIPTION
AWS Lambda doesn't support 3.6 version for python anymore